### PR TITLE
feat: add ULID support for Polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2025-08-04]
+### Added
+- Polls now use a unique, nullable ULID as an identifier.
+- Poll creation automatically generates and saves a ULID for each new poll.
+- Route model binding for polls now uses the ULID.
+- Tests updated to assert that a ULID is generated for new polls.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
 ## [2025-08-04]
+
 ### Added
+
 - Polls now use a unique, nullable ULID as an identifier.
 - Poll creation automatically generates and saves a ULID for each new poll.
 - Route model binding for polls now uses the ULID.
 - Tests updated to assert that a ULID is generated for new polls.
-

--- a/database/migrations/2025_08_04_205809_add_ulid_to_polls_table.php
+++ b/database/migrations/2025_08_04_205809_add_ulid_to_polls_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('polls', function (Blueprint $table) {
+            $table->ulid('ulid')->nullable()->unique()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('polls', function (Blueprint $table) {
+            $table->dropColumn('ulid');
+        });
+    }
+};

--- a/resources/views/livewire/pages/dashboard.blade.php
+++ b/resources/views/livewire/pages/dashboard.blade.php
@@ -3,6 +3,7 @@
 use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 use Livewire\Volt\Component;
 
 new class extends Component {
@@ -46,6 +47,7 @@ new class extends Component {
         $poll = Auth::user()->polls()->create([
             'name' => $name,
             'question' => $question,
+            'ulid' => Str::ulid(),
         ]);
 
         $poll->options()->createMany($this->formatPollOptions($options));

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,7 @@ use Livewire\Volt\Volt;
 
 Volt::route('/', 'pages.welcome')->name('home');
 
-Volt::route('p/{poll}', 'pages.polls.vote')->name('polls.vote');
+Volt::route('p/{poll:ulid}', 'pages.polls.vote')->name('polls.vote');
 
 Route::middleware(['auth', 'verified', EnsureUserIsSubscribed::class])->group(function () {
     Volt::route('dashboard', 'pages.dashboard')->name('dashboard');

--- a/tests/Feature/PollTest.php
+++ b/tests/Feature/PollTest.php
@@ -24,6 +24,8 @@ it('creates a poll with a name a question and at least two poll options', functi
         expect($poll->options)->toHaveCount(2);
         expect($poll->options[0]->label)->toBe('Option 1');
         expect($poll->options[1]->label)->toBe('Option 2');
+        expect($poll->ulid)->not->toBeNull();
+        expect(strlen($poll->ulid))->toBe(26);
     });
 });
 

--- a/tests/Feature/VotePollPageTest.php
+++ b/tests/Feature/VotePollPageTest.php
@@ -10,7 +10,7 @@ use function Pest\Laravel\get;
 uses(Refreshdatabase::class);
 
 it('shows the vote poll page', function () {
-    Poll::factory()->create(['id' => '01HZYXTESTULID1234567890']);
+    Poll::factory()->create(['ulid' => '01HZYXTESTULID1234567890']);
 
     get('p/01HZYXTESTULID1234567890')->assertOk();
 });

--- a/tests/Feature/VotePollPageTest.php
+++ b/tests/Feature/VotePollPageTest.php
@@ -10,9 +10,9 @@ use function Pest\Laravel\get;
 uses(Refreshdatabase::class);
 
 it('shows the vote poll page', function () {
-    Poll::factory()->create();
+    Poll::factory()->create(['id' => '01HZYXTESTULID1234567890']);
 
-    get('p/1')->assertOk();
+    get('p/01HZYXTESTULID1234567890')->assertOk();
 });
 
 it('saves the vote', function () {


### PR DESCRIPTION
## Summary
- Adds nullable, unique ULID column to polls table
- Poll creation now generates and saves a ULID
- Route model binding for polls uses ULID
- Tests updated to assert ULID generation
- Changelog updated and reformatted to Keep a Changelog standard

🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>
