### PR TITLE
feat: store contact email with poll responses and improve responses table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ All notable changes to this project will be documented in this file.
 ## [2025-08-04]
 
 ### Added
-
 - Polls now use a unique, nullable ULID as an identifier.
 - Poll creation automatically generates and saves a ULID for each new poll.
 - Route model binding for polls now uses the ULID.
 - Tests updated to assert that a ULID is generated for new polls.
+- Poll responses now store the contact email address if provided.
+
+### Changed
+- Refactored poll option responses modal to use a single dynamic modal, opened programmatically with `Flux::modal()->show()`, improving maintainability and performance.
+- Modal now loads responses dynamically from the backend when the ellipsis button is clicked.
+- Improved poll voting UI: contact email field label and badge styling.
+- All modal and poll voting UI strings are now translatable; added missing translations for Spanish, including for modal table and contact email field.

--- a/database/migrations/2025_08_04_214124_add_contact_email_to_responses_table.php
+++ b/database/migrations/2025_08_04_214124_add_contact_email_to_responses_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('responses', function (Blueprint $table) {
+            $table->string('contact_email')->nullable()->after('option_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('responses', function (Blueprint $table) {
+            $table->dropColumn('contact_email');
+        });
+    }
+};

--- a/docs/changelog/2025-08-04-contact-email-and-response-table.md
+++ b/docs/changelog/2025-08-04-contact-email-and-response-table.md
@@ -1,0 +1,7 @@
+# Las respuestas a encuestas ahora pueden incluir correo de contacto
+
+Uno de los problemas al usar encuestas en [Terrific Poll](https://poll.terrific.com.mx) es no saber quién envió cada respuesta. Esto dificulta el seguimiento, la comunicación con los participantes o la prevención de votos duplicados.
+
+Ahora, de forma opcional, que quienes votan en una encuesta proporcionen su correo electrónico de contacto.
+
+Además, todas las respuestas recibidas para cada opción pueden visualizarse en una tabla clara y ordenable desde la interfaz de administración. Así, es sencillo revisar quién votó por qué opción y cuándo, directamente desde tu panel de control.

--- a/docs/changelog/2025-08-04-contact-email-and-response-table.md
+++ b/docs/changelog/2025-08-04-contact-email-and-response-table.md
@@ -1,7 +1,7 @@
 # Las respuestas a encuestas ahora pueden incluir correo de contacto
 
-Uno de los problemas al usar encuestas en [Terrific Poll](https://poll.terrific.com.mx) es no saber quién envió cada respuesta. Esto dificulta el seguimiento, la comunicación con los participantes o la prevención de votos duplicados.
+Uno de los problemas al usar encuestas en [Terrific Poll](https://poll.terrific.com.mx) es no saber quién envió cada respuesta. Esto dificulta el seguimiento y la comunicación con los participantes.
 
-Ahora, de forma opcional, que quienes votan en una encuesta proporcionen su correo electrónico de contacto.
+Ahora, quienes votan en una encuesta pueden, de forma opcional, proporcionar su correo electrónico de contacto. Esta mejora permite identificar a los participantes y facilita el seguimiento o la comunicación posterior.
 
 Además, todas las respuestas recibidas para cada opción pueden visualizarse en una tabla clara y ordenable desde la interfaz de administración. Así, es sencillo revisar quién votó por qué opción y cuándo, directamente desde tu panel de control.

--- a/docs/changelog/2025-08-04-contact-email-and-response-table.md
+++ b/docs/changelog/2025-08-04-contact-email-and-response-table.md
@@ -4,4 +4,4 @@ Uno de los problemas al usar encuestas en [Terrific Poll](https://poll.terrific.
 
 Ahora, quienes votan en una encuesta pueden, de forma opcional, proporcionar su correo electrónico de contacto. Esta mejora permite identificar a los participantes y facilita el seguimiento o la comunicación posterior.
 
-Además, todas las respuestas recibidas para cada opción pueden visualizarse en una tabla clara y ordenable desde la interfaz de administración. Así, es sencillo revisar quién votó por qué opción y cuándo, directamente desde tu panel de control.
+Además, todas las respuestas recibidas para cada opción pueden visualizarse en una tabla desde la interfaz de administración. Así, es sencillo revisar quién votó por qué opción y cuándo, directamente desde tu panel de control.

--- a/lang/es.json
+++ b/lang/es.json
@@ -66,5 +66,7 @@
     "Poll Options": "Opciones de la encuesta",
     "Add another option": "Agregar otra opción",
     "Your email": "Tu correo electrónico",
-    "Optional": "Opcional"
+    "Optional": "Opcional",
+    "Thank you for voting!": "¡Gracias por votar!",
+    "Submit": "Enviar"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -64,5 +64,7 @@
     "Question": "Pregunta",
     "Options": "Opciones",
     "Poll Options": "Opciones de la encuesta",
-    "Add another option": "Agregar otra opción"
+    "Add another option": "Agregar otra opción",
+    "Your email": "Tu correo electrónico",
+    "Optional": "Opcional"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -68,5 +68,9 @@
     "Your email": "Tu correo electrónico",
     "Optional": "Opcional",
     "Thank you for voting!": "¡Gracias por votar!",
-    "Submit": "Enviar"
+    "Submit": "Enviar",
+    "Responses for": "Respuestas para",
+    "Date": "Fecha",
+    "No responses for this option yet.": "Aún no hay respuestas para esta opción.",
+    "Anonymous": "Anónimo"
 }

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -1,16 +1,28 @@
 <?php
 
+use App\Models\Option;
 use App\Models\Poll;
+use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Volt\Component;
 
 new class extends Component {
     public Poll $poll;
     public Collection $options;
+    public $selectedOption = null;
+    public $selectedResponses = null;
 
     public function mount()
     {
         $this->options = $this->poll->options()->withCount('responses')->get();
+    }
+
+    public function showResponses(Option $option)
+    {
+        $this->selectedOption = $option;
+        $this->selectedResponses = $this->selectedOption->responses()->latest()->get();
+
+        Flux::modal('show-responses-modal')->show();
     }
 }; ?>
 
@@ -62,34 +74,7 @@ new class extends Component {
                             <flux:table.cell>{{ $option->label }}</flux:table.cell>
                             <flux:table.cell>{{ $option->responses_count }}</flux:table.cell>
                             <flux:table.cell>
-                                <flux:modal.trigger name="show-responses-{{ $option->id }}">
-                                    <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom"></flux:button>
-                                </flux:modal.trigger>
-                                <flux:modal name="show-responses-{{ $option->id }}" class="md:w-96" variant="flyout">
-                                    <div class="space-y-6">
-                                        <div>
-                                            <flux:heading size="lg">{{ __('Responses for') }} {{ $option->label }}</flux:heading>
-                                        </div>
-                                        @if($option->responses && $option->responses->count())
-                                            <flux:table>
-                                                <flux:table.columns>
-                                                    <flux:table.column>{{ __('Email') }}</flux:table.column>
-                                                    <flux:table.column>{{ __('Date') }}</flux:table.column>
-                                                </flux:table.columns>
-                                                <flux:table.rows>
-                                                    @foreach($option->responses as $response)
-                                                        <flux:table.row :key="$response->id">
-                                                            <flux:table.cell>{{ $response->contact_email ?? __('Anonymous') }}</flux:table.cell>
-                                                            <flux:table.cell>{{ $response->created_at->format('Y-m-d') }}</flux:table.cell>
-                                                        </flux:table.row>
-                                                    @endforeach
-                                                </flux:table.rows>
-                                            </flux:table>
-                                        @else
-                                            <flux:text>{{ __('No responses for this option yet.') }}</flux:text>
-                                        @endif
-                                    </div>
-                                </flux:modal>
+                                <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom" wire:click="showResponses({{ $option->id }})"></flux:button>
                             </flux:table.cell>
                         </flux:table.row>
                     @endforeach
@@ -99,4 +84,30 @@ new class extends Component {
             <flux:text>{{ __('No responses yet.') }}</flux:text>
         @endif
     </div>
+
+    <flux:modal name="show-responses-modal" class="md:w-96" variant="flyout">
+        <div class="space-y-6">
+            <div>
+                <flux:heading size="lg">{{ __('Responses for') }} {{ $selectedOption?->label }}</flux:heading>
+            </div>
+            @if($selectedResponses && $selectedResponses->count())
+                <flux:table>
+                    <flux:table.columns>
+                        <flux:table.column>{{ __('Email') }}</flux:table.column>
+                        <flux:table.column>{{ __('Date') }}</flux:table.column>
+                    </flux:table.columns>
+                    <flux:table.rows>
+                        @foreach($selectedResponses as $response)
+                            <flux:table.row :key="$response->id">
+                                <flux:table.cell>{{ $response->contact_email ?? __('Anonymous') }}</flux:table.cell>
+                                <flux:table.cell>{{ $response->created_at->format('Y-m-d') }}</flux:table.cell>
+                            </flux:table.row>
+                        @endforeach
+                    </flux:table.rows>
+                </flux:table>
+            @else
+                <flux:text>{{ __('No responses for this option yet.') }}</flux:text>
+            @endif
+        </div>
+    </flux:modal>
 </div>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -61,6 +61,36 @@ new class extends Component {
                         <flux:table.row>
                             <flux:table.cell>{{ $option->label }}</flux:table.cell>
                             <flux:table.cell>{{ $option->responses_count }}</flux:table.cell>
+                            <flux:table.cell>
+                                <flux:modal.trigger name="show-responses-{{ $option->id }}">
+                                    <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom"></flux:button>
+                                </flux:modal.trigger>
+                                <flux:modal name="show-responses-{{ $option->id }}" class="md:w-96" variant="flyout">
+                                    <div class="space-y-6">
+                                        <div>
+                                            <flux:heading size="lg">{{ __('Responses for') }} {{ $option->label }}</flux:heading>
+                                        </div>
+                                        @if($option->responses && $option->responses->count())
+                                            <flux:table>
+                                                <flux:table.columns>
+                                                    <flux:table.column>{{ __('Email') }}</flux:table.column>
+                                                    <flux:table.column>{{ __('Date') }}</flux:table.column>
+                                                </flux:table.columns>
+                                                <flux:table.rows>
+                                                    @foreach($option->responses as $response)
+                                                        <flux:table.row :key="$response->id">
+                                                            <flux:table.cell>{{ $response->contact_email ?? __('Anonymous') }}</flux:table.cell>
+                                                            <flux:table.cell>{{ $response->created_at->format('Y-m-d') }}</flux:table.cell>
+                                                        </flux:table.row>
+                                                    @endforeach
+                                                </flux:table.rows>
+                                            </flux:table>
+                                        @else
+                                            <flux:text>{{ __('No responses for this option yet.') }}</flux:text>
+                                        @endif
+                                    </div>
+                                </flux:modal>
+                            </flux:table.cell>
                         </flux:table.row>
                     @endforeach
                 </flux:table.rows>

--- a/resources/views/livewire/pages/polls/vote.blade.php
+++ b/resources/views/livewire/pages/polls/vote.blade.php
@@ -13,6 +13,9 @@ new #[Layout('components.layouts.guest')] class extends Component {
     #[Validate('required|exists:options,id')]
     public $option = '';
 
+    #[Validate('nullable|email')]
+    public $contact_email = '';
+
     public $submitted = false;
 
     public function vote()
@@ -21,6 +24,7 @@ new #[Layout('components.layouts.guest')] class extends Component {
 
         $this->poll->responses()->create([
             'option_id' => $this->option,
+            'contact_email' => $this->contact_email,
         ]);
 
         $this->submitted = true;
@@ -37,6 +41,13 @@ new #[Layout('components.layouts.guest')] class extends Component {
                     <flux:radio value="{{ $option->id }}" label="{{ $option->label }}" />
                 @endforeach
             </flux:radio.group>
+
+            <flux:input
+                type="email"
+                wire:model="contact_email"
+                label="{{ __('Your email (optional)') }}"
+                placeholder="you@example.com"
+            />
 
             <flux:button type="submit" variant="primary">
                 {{ __('Submit') }}

--- a/resources/views/livewire/pages/polls/vote.blade.php
+++ b/resources/views/livewire/pages/polls/vote.blade.php
@@ -45,8 +45,8 @@ new #[Layout('components.layouts.guest')] class extends Component {
             <flux:input
                 type="email"
                 wire:model="contact_email"
-                label="{{ __('Your email (optional)') }}"
-                placeholder="you@example.com"
+                label="{{ __('Your email') }}"
+                badge="{{ __('Optional') }}"
             />
 
             <flux:button type="submit" variant="primary">

--- a/tests/Feature/VotePollPageTest.php
+++ b/tests/Feature/VotePollPageTest.php
@@ -26,3 +26,17 @@ it('saves the vote', function () {
     expect($poll->responses()->count())->toBe(1);
     expect($poll->responses()->first()->option_id)->toBe($option->id);
 });
+
+it('saves the contact email with the vote', function () {
+    $poll = Poll::factory()->create();
+    $option = Option::factory()->for($poll)->create();
+    $email = 'test@example.com';
+
+    Volt::test('pages.polls.vote', ['poll' => $poll])
+        ->set('option', $option->id)
+        ->set('contact_email', $email)
+        ->call('vote');
+
+    $response = $poll->responses()->first();
+    expect($response->contact_email)->toBe($email);
+});


### PR DESCRIPTION
## Summary
- Adds optional contact email field to poll responses and database.
- Refactors poll option responses modal to use a dynamic modal and loads responses on demand.
- Improves UI and adds missing translations for poll voting and responses table.
- Updates changelog and adds tests for contact email storage.

## Test plan
- [x] Run all tests: 
   PASS  Tests\Unit\ExampleTest
  ✓ that true is true                                                    0.01s  

   PASS  Tests\Feature\Auth\AuthenticationTest
  ✓ login screen can be rendered                                         0.18s  
  ✓ users can authenticate using the login screen                        0.49s  
  ✓ users can not authenticate with invalid password                     0.24s  
  ✓ users can logout                                                     0.01s  

   PASS  Tests\Feature\Auth\EmailVerificationTest
  ✓ email verification screen can be rendered                            0.02s  
  ✓ email can be verified                                                0.01s  
  ✓ email is not verified with invalid hash                              0.02s  

   PASS  Tests\Feature\Auth\PasswordConfirmationTest
  ✓ confirm password screen can be rendered                              0.03s  
  ✓ password can be confirmed                                            0.03s  
  ✓ password is not confirmed with invalid password                      0.23s  

   PASS  Tests\Feature\Auth\PasswordResetTest
  ✓ reset password link screen can be rendered                           0.03s  
  ✓ reset password link can be requested                                 0.23s  
  ✓ reset password screen can be rendered                                0.24s  
  ✓ password can be reset with valid token                               0.27s  

   PASS  Tests\Feature\Auth\RegistrationTest
  ✓ registration screen can be rendered                                  0.02s  
  ✓ new users can register                                               0.06s  

   PASS  Tests\Feature\BillingPortalTest
  ✓ it redirects unsubscribed user to dashboard                          0.02s  

   PASS  Tests\Feature\DashboardTest
  ✓ guests are redirected to the login page                              0.01s  
  ✓ authenticated users can visit the dashboard                          0.07s  

   PASS  Tests\Feature\EnsureUserIsSubscribedTest
  ✓ it redirects unsubscribed users to the subscription-required page w… 0.01s  

   PASS  Tests\Feature\ExampleTest
  ✓ it returns a successful response                                     0.01s  

   PASS  Tests\Feature\PollTest - 3 todos
  ✓ it creates a poll with a name a question and at least two poll opti… 0.13s  
  ↓ create an endpoint to view the poll like /p/{pollUuid}               0.01s  
  ↓ store visitor responses to the poll                                  0.01s  
  ↓ optionally store visitor email to the poll response                  0.01s  

   PASS  Tests\Feature\Settings\PasswordUpdateTest
  ✓ password can be updated                                              0.05s  
  ✓ correct password must be provided to update password                 0.05s  

   PASS  Tests\Feature\Settings\ProfileUpdateTest
  ✓ profile page is displayed                                            0.03s  
  ✓ profile information can be updated                                   0.04s  
  ✓ email verification status is unchanged when email address is unchan… 0.04s  
  ✓ user can delete their account                                        0.02s  
  ✓ correct password must be provided to delete account                  0.03s  

   PASS  Tests\Feature\ShowPollPageTest
  ✓ it shows the poll page                                               0.03s  
  ✓ it redirects guest to login page                                     0.01s  

   PASS  Tests\Feature\SubscriptionRequiredPageTest
  ✓ it redirects a subscribed user to the dashboard when accessing the…  0.01s  

   PASS  Tests\Feature\VotePollPageTest
  ✓ it shows the vote poll page                                          0.02s  
  ✓ it saves the vote                                                    0.05s  
  ✓ it saves the contact email with the vote                             0.03s  

  Tests:    3 todos, 36 passed (86 assertions)
  Duration: 2.89s
- [x] Manually test poll voting with and without contact email.
- [x] Verify responses table displays emails and dates correctly in admin UI.
- [x] Check Spanish translations for new UI elements.

🤖 Generated with [opencode](https://opencode.ai)
