### PR TITLE
feat: embed polls in newsletters with contact email merge tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2025-08-05]
+
+### Added
+- Embed polls in newsletters: new modal on poll page provides ready-to-copy HTML for Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite, and Sendy, each with the correct merge tag to prepopulate the contact email field for each subscriber.
+- Copy-to-clipboard button for newsletter embed HTML, with support for rich markup.
+- All new UI and strings are fully translatable and available in Spanish.
+
+### Changed
+- Poll voting page now allows prepopulating and clearing the contact_email field via URL and UI, improving the experience for newsletter recipients.
+
 ## [2025-08-04]
 
 ### Added

--- a/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
+++ b/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
@@ -1,6 +1,6 @@
 # Prellenado automático del correo de contacto en encuestas incrustadas en newsletters
 
-Hasta ahora, cuando los destinatarios visitaban la página de votación de una encuesta de Terrific Poll, debían opcionalmente ingresar manualmente su dirección de correo electrónico en el campo email de contacto. Este paso adicional generaba fricción y dificultaba el seguimiento individual de las respuestas provenientes de campañas de newsletter.
+Hasta ahora, cuando los destinatarios visitaban la página de votación de una encuesta de [Terrific Poll](https://poll.terrific.com.mx), debían opcionalmente ingresar manualmente su dirección de correo electrónico en el [campo email de contacto](./2025-08-04-contact-email-and-response-table.md). Este paso adicional generaba fricción y dificultaba el seguimiento individual de las respuestas provenientes de campañas de newsletter.
 
 Para resolverlo, ahora es posible prellenar automáticamente el campo email de contacto utilizando los merge tags que ofrecen las principales plataformas de newsletter (como Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite y Sendy). Cada servicio utiliza su propio merge tag para insertar dinámicamente el correo del suscriptor.
 

--- a/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
+++ b/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
@@ -1,9 +1,10 @@
 # Prellenado automático del correo de contacto en encuestas incrustadas en newsletters
 
-Hasta ahora, cuando los destinatarios visitaban la página de votación de una encuesta de [Terrific Poll](https://poll.terrific.com.mx), debían opcionalmente ingresar manualmente su dirección de correo electrónico en el [campo email de contacto](./2025-08-04-contact-email-and-response-table.md). Este paso adicional generaba fricción y dificultaba el seguimiento individual de las respuestas provenientes de campañas de newsletter.
+Hasta ahora, cuando tú o tus destinatarios visitaban la página de votación de una encuesta de [Terrific Poll](https://poll.terrific.com.mx), debían ingresar manualmente su dirección de correo electrónico en el [campo email de contacto](./2025-08-04-contact-email-and-response-table.md) si querían dejarlo. Este paso adicional podía generar fricción y dificultar el seguimiento individual de las respuestas provenientes de tus campañas de newsletter.
 
-Para resolverlo, ahora es posible prellenar automáticamente el campo email de contacto utilizando los merge tags que ofrecen las principales plataformas de newsletter (como Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite y Sendy). Cada servicio utiliza su propio merge tag para insertar dinámicamente el correo del suscriptor.
+Para resolverlo, ahora puedes prellenar automáticamente el campo email de contacto usando los merge tags que ofrecen las principales plataformas de newsletter (como Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite y Sendy). Cada servicio utiliza su propio merge tag para insertar dinámicamente el correo de tu suscriptor.
 
-Desde la página de cada encuesta, encontrarás un nuevo botón “Insertar en newsletter” que abre un modal con fragmentos de HTML listos para copiar y pegar en tu plataforma favorita, usando el merge tag adecuado para prellenar el correo de contacto. El modal permite copiar el HTML con un solo clic.
+Desde la página de cada encuesta, encontrarás un nuevo botón “Insertar en newsletter” que abre un modal con fragmentos de HTML listos para que los copies y pegues en tu plataforma favorita, usando el merge tag adecuado para prellenar el correo de contacto. Puedes copiar el HTML con un solo clic.
 
-Además, la página de votación ahora permite prellenar y limpiar el campo de correo de contacto mediante la URL o un botón en la interfaz, facilitando la respuesta de los destinatarios sin necesidad de ingreso manual.
+Además, la página de votación ahora te permite prellenar y limpiar el campo de correo de contacto mediante la URL o un botón en la interfaz, facilitando que tus destinatarios respondan sin necesidad de ingresar manualmente su correo.
+

--- a/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
+++ b/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
@@ -1,4 +1,4 @@
-# Prellenado y anonimato en encuestas de newsletters
+# Prellenado automático del correo de contacto en encuestas incrustadas en newsletters
 
 Hasta ahora, tus destinatarios visitaban la página de votación de una encuesta de [Terrific Poll](https://poll.terrific.com.mx), debían ingresar manualmente su dirección de correo electrónico en el [campo email de contacto](./2025-08-04-contact-email-and-response-table.md) si querían dejarlo. Este paso adicional podía generar fricción y dificultar el seguimiento individual de las respuestas provenientes de tus campañas de newsletter.
 

--- a/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
+++ b/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
@@ -1,15 +1,9 @@
-# Inserta encuestas en newsletters y prellena el correo de contacto
+# Prellenado automático del correo de contacto en encuestas incrustadas en newsletters
 
-Ahora puedes insertar fácilmente tus encuestas de Terrific Poll en plataformas de newsletter como Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite y Sendy. Desde la página de cada encuesta, encontrarás un nuevo botón "Insertar en newsletter" que abre un modal con el código HTML listo para copiar y pegar en tu plataforma favorita.
+Hasta ahora, cuando los destinatarios visitaban la página de votación de una encuesta de Terrific Poll, debían opcionalmente ingresar manualmente su dirección de correo electrónico en el campo email de contacto. Este paso adicional generaba fricción y dificultaba el seguimiento individual de las respuestas provenientes de campañas de newsletter.
 
-Cada servicio utiliza su propio merge tag para prellenar el campo de correo de contacto de cada suscriptor, facilitando el seguimiento de respuestas individuales sin fricción para el usuario. El modal permite copiar el HTML con un solo clic y está completamente traducido al español.
+Para resolverlo, ahora es posible prellenar automáticamente el campo email de contacto utilizando los merge tags que ofrecen las principales plataformas de newsletter (como Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite y Sendy). Cada servicio utiliza su propio merge tag para insertar dinámicamente el correo del suscriptor.
 
-Además, la página de votación ahora permite prellenar y limpiar el campo de correo de contacto mediante la URL o un botón en la interfaz, mejorando la experiencia para quienes responden desde newsletters.
+Desde la página de cada encuesta, encontrarás un nuevo botón “Insertar en newsletter” que abre un modal con fragmentos de HTML listos para copiar y pegar en tu plataforma favorita, usando el merge tag adecuado para prellenar el correo de contacto. El modal permite copiar el HTML con un solo clic.
 
-**Mejoras incluidas:**
-- Modal para insertar encuestas en newsletters con soporte para múltiples servicios y merge tags.
-- Copia rápida del HTML personalizado para cada plataforma.
-- Prellenado automático del correo de contacto en la página de votación.
-- Todo el nuevo UI es traducible y funciona en español.
-
-¡Ahora es más fácil que nunca recolectar respuestas personalizadas desde tus campañas de email!
+Además, la página de votación ahora permite prellenar y limpiar el campo de correo de contacto mediante la URL o un botón en la interfaz, facilitando la respuesta de los destinatarios sin necesidad de ingreso manual.

--- a/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
+++ b/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
@@ -1,4 +1,4 @@
-# Prellenado automático del correo de contacto en encuestas incrustadas en newsletters
+# Prellenado y anonimato en encuestas de newsletters
 
 Hasta ahora, tus destinatarios visitaban la página de votación de una encuesta de [Terrific Poll](https://poll.terrific.com.mx), debían ingresar manualmente su dirección de correo electrónico en el [campo email de contacto](./2025-08-04-contact-email-and-response-table.md) si querían dejarlo. Este paso adicional podía generar fricción y dificultar el seguimiento individual de las respuestas provenientes de tus campañas de newsletter.
 
@@ -6,5 +6,4 @@ Para resolverlo, ahora puedes prellenar automáticamente el campo email de conta
 
 Desde la página de cada encuesta, encontrarás un nuevo botón “Insertar en newsletter” que abre un modal con fragmentos de HTML listos para que los copies y pegues en tu plataforma favorita, usando el merge tag adecuado para prellenar el correo de contacto. Puedes copiar el HTML con un solo clic.
 
-Además, la página de votación ahora incluye un botón opcional para borrar el correo de contacto prellenado. Así, tus destinatarios pueden decidir fácilmente si desean enviar su respuesta de forma anónima, simplemente eliminando su correo antes de votar.
-
+Además, la página de votación incluye un botón opcional para borrar el correo de contacto prellenado. Así, tus destinatarios pueden decidir fácilmente si desean enviar su respuesta de forma anónima, simplemente eliminando su correo antes de votar.

--- a/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
+++ b/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
@@ -1,10 +1,10 @@
 # Prellenado automático del correo de contacto en encuestas incrustadas en newsletters
 
-Hasta ahora, cuando tú o tus destinatarios visitaban la página de votación de una encuesta de [Terrific Poll](https://poll.terrific.com.mx), debían ingresar manualmente su dirección de correo electrónico en el [campo email de contacto](./2025-08-04-contact-email-and-response-table.md) si querían dejarlo. Este paso adicional podía generar fricción y dificultar el seguimiento individual de las respuestas provenientes de tus campañas de newsletter.
+Hasta ahora, tus destinatarios visitaban la página de votación de una encuesta de [Terrific Poll](https://poll.terrific.com.mx), debían ingresar manualmente su dirección de correo electrónico en el [campo email de contacto](./2025-08-04-contact-email-and-response-table.md) si querían dejarlo. Este paso adicional podía generar fricción y dificultar el seguimiento individual de las respuestas provenientes de tus campañas de newsletter.
 
 Para resolverlo, ahora puedes prellenar automáticamente el campo email de contacto usando los merge tags que ofrecen las principales plataformas de newsletter (como Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite y Sendy). Cada servicio utiliza su propio merge tag para insertar dinámicamente el correo de tu suscriptor.
 
 Desde la página de cada encuesta, encontrarás un nuevo botón “Insertar en newsletter” que abre un modal con fragmentos de HTML listos para que los copies y pegues en tu plataforma favorita, usando el merge tag adecuado para prellenar el correo de contacto. Puedes copiar el HTML con un solo clic.
 
-Además, la página de votación ahora te permite prellenar y limpiar el campo de correo de contacto mediante la URL o un botón en la interfaz, facilitando que tus destinatarios respondan sin necesidad de ingresar manualmente su correo.
+Además, la página de votación ahora incluye un botón opcional para borrar el correo de contacto prellenado. Así, tus destinatarios pueden decidir fácilmente si desean enviar su respuesta de forma anónima, simplemente eliminando su correo antes de votar.
 

--- a/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
+++ b/docs/changelog/2025-08-05-embed-polls-in-newsletters.md
@@ -1,0 +1,15 @@
+# Inserta encuestas en newsletters y prellena el correo de contacto
+
+Ahora puedes insertar fácilmente tus encuestas de Terrific Poll en plataformas de newsletter como Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite y Sendy. Desde la página de cada encuesta, encontrarás un nuevo botón "Insertar en newsletter" que abre un modal con el código HTML listo para copiar y pegar en tu plataforma favorita.
+
+Cada servicio utiliza su propio merge tag para prellenar el campo de correo de contacto de cada suscriptor, facilitando el seguimiento de respuestas individuales sin fricción para el usuario. El modal permite copiar el HTML con un solo clic y está completamente traducido al español.
+
+Además, la página de votación ahora permite prellenar y limpiar el campo de correo de contacto mediante la URL o un botón en la interfaz, mejorando la experiencia para quienes responden desde newsletters.
+
+**Mejoras incluidas:**
+- Modal para insertar encuestas en newsletters con soporte para múltiples servicios y merge tags.
+- Copia rápida del HTML personalizado para cada plataforma.
+- Prellenado automático del correo de contacto en la página de votación.
+- Todo el nuevo UI es traducible y funciona en español.
+
+¡Ahora es más fácil que nunca recolectar respuestas personalizadas desde tus campañas de email!

--- a/lang/es.json
+++ b/lang/es.json
@@ -9,6 +9,7 @@
     "Confirm Password": "Confirmar contraseña",
     "Copied!": "¡Copiado!",
     "Copy embed code": "Copiar código de inserción",
+    "Copy": "Copiar",
     "Count": "Cantidad",
     "Create a New Poll": "Crear una nueva encuesta",
     "Create account": "Crear cuenta",
@@ -72,5 +73,7 @@
     "Responses for": "Respuestas para",
     "Date": "Fecha",
     "No responses for this option yet.": "Aún no hay respuestas para esta opción.",
-    "Anonymous": "Anónimo"
+    "Anonymous": "Anónimo",
+    "Embed in Newsletter": "Insertar en newsletter",
+    "Copy and paste this markup into your newsletter platform. The links will prepopulate the contact email field for each subscriber.": "Copia y pega este marcado en tu plataforma de newsletter. Los enlaces rellenarán automáticamente el campo de correo electrónico para cada suscriptor."
 }

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -122,7 +122,26 @@ new class extends Component {
         </div>
     </flux:modal>
 
-    <flux:modal name="embed-newsletter" class="md:w-96">
+    <flux:modal name="embed-newsletter" class="md:w-96" x-data="{
+    copied: false,
+    copyNewsletter(ref) {
+        const ul = this.$refs[ref];
+        if (!ul) return;
+        const html = ul.outerHTML;
+        if (navigator.clipboard && window.ClipboardItem) {
+            const blob = new Blob([html], { type: 'text/html' });
+            const item = new ClipboardItem({ 'text/html': blob });
+            navigator.clipboard.write([item]).then(() => {
+                this.copied = true;
+                setTimeout(() => this.copied = false, 1500);
+            });
+        } else {
+            navigator.clipboard.writeText(html);
+            this.copied = true;
+            setTimeout(() => this.copied = false, 1500);
+        }
+    }
+}">
         <div class="space-y-6">
             <div>
                 <flux:heading size="lg">Embed in Newsletter</flux:heading>
@@ -138,7 +157,7 @@ new class extends Component {
                     <flux:tab.panel name="{{ $key }}">
                         <div class="newsletter-embed-{{ $key }}">
                             <div class="font-medium">{{ $poll->question }}</div>
-                            <ul class="mt-6 text-sm space-y-2 list-disc ml-6">
+                            <ul class="mt-6 text-sm space-y-2 list-disc ml-6" x-ref="newsletter{{ ucfirst($key) }}">
                                 @foreach ($poll->options as $option)
                                     <li>
                                         <a href="{{ route('polls.vote', [
@@ -157,14 +176,8 @@ new class extends Component {
                             <flux:button
                                 type="button"
                                 variant="primary"
-                                onclick="const html = this.closest('.mb-6').querySelector('.newsletter-embed-{{ $key }}').outerHTML;
-                                    if (navigator.clipboard && window.ClipboardItem) {
-                                        const blob = new Blob([html], { type: 'text/html' });
-                                        const item = new ClipboardItem({ 'text/html': blob });
-                                        navigator.clipboard.write([item]);
-                                    } else {
-                                        navigator.clipboard.writeText(html);
-                                    }"
+                                @click="copyNewsletter('newsletter{{ ucfirst($key) }}')"
+                                x-text="copied ? 'Copied!' : 'Copy'"
                             >Copy</flux:button>
                         </div>
                     </flux:tab.panel>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -123,25 +123,21 @@ new class extends Component {
     </flux:modal>
 
     <flux:modal name="embed-newsletter" class="md:w-96" x-data="{
-    copied: false,
-    copyNewsletter(ref) {
-        const ul = this.$refs[ref];
-        if (!ul) return;
-        const html = ul.outerHTML;
-        if (navigator.clipboard && window.ClipboardItem) {
-            const blob = new Blob([html], { type: 'text/html' });
-            const item = new ClipboardItem({ 'text/html': blob });
-            navigator.clipboard.write([item]).then(() => {
-                this.copied = true;
-                setTimeout(() => this.copied = false, 1500);
-            });
-        } else {
-            navigator.clipboard.writeText(html);
-            this.copied = true;
-            setTimeout(() => this.copied = false, 1500);
+        copied: false,
+        copyNewsletter(ref) {
+            const html = this.$refs[ref].innerHTML;
+
+            if (navigator.clipboard && window.ClipboardItem) {
+                const blob = new Blob([html], { type: 'text/html' });
+                const item = new ClipboardItem({ 'text/html': blob });
+
+                navigator.clipboard.write([item]).then(() => {
+                    this.copied = true;
+                    setTimeout(() => this.copied = false, 1500);
+                });
+            }
         }
-    }
-}">
+    }">
         <div class="space-y-6">
             <div>
                 <flux:heading size="lg">Embed in Newsletter</flux:heading>
@@ -155,9 +151,9 @@ new class extends Component {
                 </flux:tabs>
                 @foreach ($this->newsletterServices as $key => $service)
                     <flux:tab.panel name="{{ $key }}">
-                        <div class="newsletter-embed-{{ $key }}">
+                        <div x-ref="newsletter{{ ucfirst($key) }}">
                             <div class="font-medium">{{ $poll->question }}</div>
-                            <ul class="mt-6 text-sm space-y-2 list-disc ml-6" x-ref="newsletter{{ ucfirst($key) }}">
+                            <ul class="mt-6 text-sm space-y-2 list-disc ml-6">
                                 @foreach ($poll->options as $option)
                                     <li>
                                         <a href="{{ route('polls.vote', [

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -47,7 +47,7 @@ new class extends Component {
         <div class="flex gap-2">
             <flux:button variant="primary" @click="copyEmbed" x-text="copied ? '{{ __('Copied!') }}' : '{{ __('Copy embed code') }}'">{{ __('Copy embed code') }}</flux:button>
             <flux:modal.trigger name="embed-newsletter">
-                <flux:button variant="secondary" icon="book-open-text">{{ __('Embed in Newsletter') }}</flux:button>
+                <flux:button icon="book-open-text">{{ __('Embed in Newsletter') }}</flux:button>
             </flux:modal.trigger>
         </div>
     </div>
@@ -101,9 +101,9 @@ new class extends Component {
             <div>
                 <label class="block text-sm font-medium mb-1">Newsletter Service</label>
                 <select x-model="service" class="w-full rounded border-zinc-300">
-                    <option value="kit">Kit ({{'{{ subscriber.email_address }}'}})</option>
-                    <option value="beehiiv">Beehiiv ({{'{{ email }}'}})</option>
-                    <option value="mailerlite">MailerLite ({{'{{ subscriber.email }}'}})</option>
+                    <option value="kit">Kit</option>
+                    <option value="beehiiv">Beehiiv</option>
+                    <option value="mailerlite">MailerLite</option>
                     <option value="custom">Custom</option>
                 </select>
             </div>
@@ -122,9 +122,9 @@ new class extends Component {
                 service: 'kit',
                 generateMarkup(service) {
                     const mergeTags = {
-                        kit: '{{ subscriber.email_address }}',
-                        beehiiv: '{{ email }}',
-                        mailerlite: '{{ subscriber.email }}',
+                        kit: '@{{ subscriber.email_address }}',
+                        beehiiv: '@{{ email }}',
+                        mailerlite: '@{{ subscriber.email }}',
                         custom: 'EMAIL_MERGE_TAG',
                     };
                     const pollUlid = '{{ $poll->ulid ?? $poll->id }}';

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -123,9 +123,9 @@ new class extends Component {
             </div>
             @php
                 $newsletterServices = [
-                    'kit' => ['label' => 'Kit', 'merge' => '@{{ subscriber.email_address }}'],
-                    'beehiiv' => ['label' => 'Beehiiv', 'merge' => '@{{ email }}'],
-                    'mailerlite' => ['label' => 'MailerLite', 'merge' => '@{{ subscriber.email }}'],
+                    'kit' => ['label' => 'Kit', 'merge' => '{{ subscriber.email_address }}'],
+                    'beehiiv' => ['label' => 'Beehiiv', 'merge' => '{{ email }}'],
+                    'mailerlite' => ['label' => 'MailerLite', 'merge' => '{{ subscriber.email }}'],
                     'custom' => ['label' => 'Custom', 'merge' => 'EMAIL_MERGE_TAG'],
                 ];
                 $pollUlid = $poll->ulid ?? $poll->id;
@@ -138,7 +138,14 @@ new class extends Component {
                         <button
                             type="button"
                             class="text-xs px-2 py-1 rounded bg-zinc-200 hover:bg-zinc-300"
-                            onclick="navigator.clipboard.writeText(this.closest('.mb-6').querySelector('.newsletter-embed-{{ $key }}').outerHTML)"
+                            onclick="const html = this.closest('.mb-6').querySelector('.newsletter-embed-{{ $key }}').outerHTML;
+if (navigator.clipboard && window.ClipboardItem) {
+    const blob = new Blob([html], { type: 'text/html' });
+    const item = new ClipboardItem({ 'text/html': blob });
+    navigator.clipboard.write([item]);
+} else {
+    navigator.clipboard.writeText(html);
+}"
                         >Copy</button>
                     </div>
                     <div class="newsletter-embed-{{ $key }}">

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -11,9 +11,7 @@ new class extends Component {
     public Collection $options;
     public $selectedOption = null;
     public $selectedResponses = null;
-
     public array $newsletterServices = [];
-    public string $pollUlid;
 
     public function mount()
     {
@@ -24,7 +22,6 @@ new class extends Component {
             'mailerlite' => ['label' => 'MailerLite', 'merge' => '{{ subscriber.email }}'],
             'custom' => ['label' => 'Custom', 'merge' => 'EMAIL_MERGE_TAG'],
         ];
-        $this->pollUlid = $this->poll->ulid ?? $this->poll->id;
     }
 
     public function showResponses(Option $option)
@@ -159,7 +156,11 @@ new class extends Component {
                             <ul style="margin-top:8px;">
                                 @foreach ($poll->options as $option)
                                     <li style="margin-bottom:4px;">
-                                        <a href="{{ route('polls.vote', ['poll' => $this->pollUlid]) }}?option={{ $option->id }}&contact_email={{ $service['merge'] }}">
+                                        <a href="{{ route('polls.vote', [
+                                            'poll' => $this->poll,
+                                            'option' => $option->id,
+                                            'contact_email' => $service['merge']
+                                        ]) }}">
                                             {{ $option->label }}
                                         </a>
                                     </li>
@@ -169,7 +170,6 @@ new class extends Component {
                     </flux:tab.panel>
                 @endforeach
             </flux:tab.group>
-
         </div>
     </flux:modal>
 </div>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -159,7 +159,7 @@ new class extends Component {
                             <ul style="margin-top:8px;">
                                 @foreach ($poll->options as $option)
                                     <li style="margin-bottom:4px;">
-                                        <a href="{{ url('/p/' . $this->pollUlid) }}?option={{ $option->id }}&contact_email={{ $service['merge'] }}">
+                                        <a href="{{ route('polls.vote', ['poll' => $this->pollUlid]) }}?option={{ $option->id }}&contact_email={{ $service['merge'] }}">
                                             {{ $option->label }}
                                         </a>
                                     </li>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -131,37 +131,44 @@ new class extends Component {
                 $pollUlid = $poll->ulid ?? $poll->id;
             @endphp
 
-            @foreach ($newsletterServices as $key => $service)
-                <div class="mb-6 border rounded p-4 bg-zinc-50">
-                    <div class="flex items-center justify-between mb-2">
-                        <span class="font-semibold">{{ $service['label'] }}</span>
-                        <button
-                            type="button"
-                            class="text-xs px-2 py-1 rounded bg-zinc-200 hover:bg-zinc-300"
-                            onclick="const html = this.closest('.mb-6').querySelector('.newsletter-embed-{{ $key }}').outerHTML;
-if (navigator.clipboard && window.ClipboardItem) {
-    const blob = new Blob([html], { type: 'text/html' });
-    const item = new ClipboardItem({ 'text/html': blob });
-    navigator.clipboard.write([item]);
-} else {
-    navigator.clipboard.writeText(html);
-}"
-                        >Copy</button>
-                    </div>
-                    <div class="newsletter-embed-{{ $key }}">
-                        <strong>{{ $poll->question }}</strong>
-                        <ul style="margin-top:8px;">
-                            @foreach ($poll->options as $option)
-                                <li style="margin-bottom:4px;">
-                                    <a href="{{ url('/p/' . $pollUlid) }}?option={{ $option->id }}&contact_email={{ $service['merge'] }}">
-                                        {{ $option->label }}
-                                    </a>
-                                </li>
-                            @endforeach
-                        </ul>
-                    </div>
-                </div>
-            @endforeach
+            <flux:tab.group>
+                <flux:tabs>
+                    @foreach ($newsletterServices as $key => $service)
+                        <flux:tab name="{{ $key }}">{{ $service['label'] }}</flux:tab>
+                    @endforeach
+                </flux:tabs>
+                @foreach ($newsletterServices as $key => $service)
+                    <flux:tab.panel name="{{ $key }}">
+                        <div class="flex items-center justify-between mb-2">
+                            <span class="font-semibold">{{ $service['label'] }}</span>
+                            <button
+                                type="button"
+                                class="text-xs px-2 py-1 rounded bg-zinc-200 hover:bg-zinc-300"
+                                onclick="const html = this.closest('.mb-6').querySelector('.newsletter-embed-{{ $key }}').outerHTML;
+                                    if (navigator.clipboard && window.ClipboardItem) {
+                                        const blob = new Blob([html], { type: 'text/html' });
+                                        const item = new ClipboardItem({ 'text/html': blob });
+                                        navigator.clipboard.write([item]);
+                                    } else {
+                                        navigator.clipboard.writeText(html);
+                                    }"
+                            >Copy</button>
+                        </div>
+                        <div class="newsletter-embed-{{ $key }}">
+                            <strong>{{ $poll->question }}</strong>
+                            <ul style="margin-top:8px;">
+                                @foreach ($poll->options as $option)
+                                    <li style="margin-bottom:4px;">
+                                        <a href="{{ url('/p/' . $pollUlid) }}?option={{ $option->id }}&contact_email={{ $service['merge'] }}">
+                                            {{ $option->label }}
+                                        </a>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    </flux:tab.panel>
+                @endforeach
+            </flux:tab.group>
 
         </div>
     </flux:modal>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -115,30 +115,7 @@ new class extends Component {
         </div>
     </flux:modal>
 
-    <flux:modal name="embed-newsletter" class="md:w-96" x-data="{
-        service: 'kit',
-        generateMarkup(service) {
-            const mergeTags = {
-                kit: '@{{ subscriber.email_address }}',
-                beehiiv: '@{{ email }}',
-                mailerlite: '@{{ subscriber.email }}',
-                custom: 'EMAIL_MERGE_TAG',
-            };
-            const pollUlid = '{{ $poll->ulid ?? $poll->id }}';
-            const question = @json($poll->question);
-            const options = @json($poll->options->map(fn($o) => ['id' => $o->id, 'label' => $o->label]));
-            let html = `<div><strong>${question}</strong><ul style=\"margin-top:8px;\">`;
-            options.forEach(option => {
-                html += `<li style=\"margin-bottom:4px;\"><a href=\"{{ url('/p/') }}${pollUlid}/?option=${option.id}&contact_email=${mergeTags[service]}\">${option.label}</a></li>`;
-            });
-            html += '</ul></div>';
-            return html;
-        },
-        copyMarkup() {
-            const markup = this.generateMarkup(this.service);
-            navigator.clipboard.writeText(markup);
-        }
-    }">
+    <flux:modal name="embed-newsletter" class="md:w-96">
         <div class="space-y-6">
             <div>
                 <flux:heading size="lg">Embed in Newsletter</flux:heading>
@@ -153,10 +130,7 @@ new class extends Component {
                     <option value="custom">Custom</option>
                 </select>
             </div>
-            <div>
-                <label class="block text-sm font-medium mb-1">Embed Markup</label>
-                <textarea readonly class="w-full font-mono text-xs rounded border-zinc-300 p-2 bg-zinc-50" rows="8" x-ref="embedMarkup" x-text="generateMarkup(service)"></textarea>
-            </div>
+
             <div class="flex">
                 <flux:spacer />
                 <flux:button type="button" variant="primary" @click="copyMarkup">Copy</flux:button>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -121,20 +121,41 @@ new class extends Component {
                 <flux:heading size="lg">Embed in Newsletter</flux:heading>
                 <flux:text class="mt-2">Copy and paste this markup into your newsletter platform. The links will prepopulate the contact email field for each subscriber.</flux:text>
             </div>
-            <div>
-                <label class="block text-sm font-medium mb-1">Newsletter Service</label>
-                <select x-model="service" class="w-full rounded border-zinc-300">
-                    <option value="kit">Kit</option>
-                    <option value="beehiiv">Beehiiv</option>
-                    <option value="mailerlite">MailerLite</option>
-                    <option value="custom">Custom</option>
-                </select>
-            </div>
+            @php
+                $newsletterServices = [
+                    'kit' => ['label' => 'Kit', 'merge' => '@{{ subscriber.email_address }}'],
+                    'beehiiv' => ['label' => 'Beehiiv', 'merge' => '@{{ email }}'],
+                    'mailerlite' => ['label' => 'MailerLite', 'merge' => '@{{ subscriber.email }}'],
+                    'custom' => ['label' => 'Custom', 'merge' => 'EMAIL_MERGE_TAG'],
+                ];
+                $pollUlid = $poll->ulid ?? $poll->id;
+            @endphp
 
-            <div class="flex">
-                <flux:spacer />
-                <flux:button type="button" variant="primary" @click="copyMarkup">Copy</flux:button>
-            </div>
+            @foreach ($newsletterServices as $key => $service)
+                <div class="mb-6 border rounded p-4 bg-zinc-50">
+                    <div class="flex items-center justify-between mb-2">
+                        <span class="font-semibold">{{ $service['label'] }}</span>
+                        <button
+                            type="button"
+                            class="text-xs px-2 py-1 rounded bg-zinc-200 hover:bg-zinc-300"
+                            onclick="navigator.clipboard.writeText(this.closest('.mb-6').querySelector('.newsletter-embed-{{ $key }}').outerHTML)"
+                        >Copy</button>
+                    </div>
+                    <div class="newsletter-embed-{{ $key }}">
+                        <strong>{{ $poll->question }}</strong>
+                        <ul style="margin-top:8px;">
+                            @foreach ($poll->options as $option)
+                                <li style="margin-bottom:4px;">
+                                    <a href="{{ url('/p/' . $pollUlid) }}?option={{ $option->id }}&contact_email={{ $service['merge'] }}">
+                                        {{ $option->label }}
+                                    </a>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            @endforeach
+
         </div>
     </flux:modal>
 </div>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -59,7 +59,7 @@ new class extends Component {
         <div class="flex gap-2">
             <flux:button variant="primary" @click="copyEmbed" x-text="copied ? '{{ __('Copied!') }}' : '{{ __('Copy embed code') }}'">{{ __('Copy embed code') }}</flux:button>
             <flux:modal.trigger name="embed-newsletter">
-                <flux:button icon="book-open-text">{{ __('Embed in Newsletter') }}</flux:button>
+                <flux:button>{{ __('Embed in Newsletter') }}</flux:button>
             </flux:modal.trigger>
         </div>
     </div>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -12,9 +12,19 @@ new class extends Component {
     public $selectedOption = null;
     public $selectedResponses = null;
 
+    public array $newsletterServices = [];
+    public string $pollUlid;
+
     public function mount()
     {
         $this->options = $this->poll->options()->withCount('responses')->get();
+        $this->newsletterServices = [
+            'kit' => ['label' => 'Kit', 'merge' => '{{ subscriber.email_address }}'],
+            'beehiiv' => ['label' => 'Beehiiv', 'merge' => '{{ email }}'],
+            'mailerlite' => ['label' => 'MailerLite', 'merge' => '{{ subscriber.email }}'],
+            'custom' => ['label' => 'Custom', 'merge' => 'EMAIL_MERGE_TAG'],
+        ];
+        $this->pollUlid = $this->poll->ulid ?? $this->poll->id;
     }
 
     public function showResponses(Option $option)
@@ -121,23 +131,13 @@ new class extends Component {
                 <flux:heading size="lg">Embed in Newsletter</flux:heading>
                 <flux:text class="mt-2">Copy and paste this markup into your newsletter platform. The links will prepopulate the contact email field for each subscriber.</flux:text>
             </div>
-            @php
-                $newsletterServices = [
-                    'kit' => ['label' => 'Kit', 'merge' => '{{ subscriber.email_address }}'],
-                    'beehiiv' => ['label' => 'Beehiiv', 'merge' => '{{ email }}'],
-                    'mailerlite' => ['label' => 'MailerLite', 'merge' => '{{ subscriber.email }}'],
-                    'custom' => ['label' => 'Custom', 'merge' => 'EMAIL_MERGE_TAG'],
-                ];
-                $pollUlid = $poll->ulid ?? $poll->id;
-            @endphp
-
             <flux:tab.group>
                 <flux:tabs>
-                    @foreach ($newsletterServices as $key => $service)
+                    @foreach ($this->newsletterServices as $key => $service)
                         <flux:tab name="{{ $key }}">{{ $service['label'] }}</flux:tab>
                     @endforeach
                 </flux:tabs>
-                @foreach ($newsletterServices as $key => $service)
+                @foreach ($this->newsletterServices as $key => $service)
                     <flux:tab.panel name="{{ $key }}">
                         <div class="flex items-center justify-between mb-2">
                             <span class="font-semibold">{{ $service['label'] }}</span>
@@ -159,7 +159,7 @@ new class extends Component {
                             <ul style="margin-top:8px;">
                                 @foreach ($poll->options as $option)
                                     <li style="margin-bottom:4px;">
-                                        <a href="{{ url('/p/' . $pollUlid) }}?option={{ $option->id }}&contact_email={{ $service['merge'] }}">
+                                        <a href="{{ url('/p/' . $this->pollUlid) }}?option={{ $option->id }}&contact_email={{ $service['merge'] }}">
                                             {{ $option->label }}
                                         </a>
                                     </li>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -136,11 +136,27 @@ new class extends Component {
                 </flux:tabs>
                 @foreach ($this->newsletterServices as $key => $service)
                     <flux:tab.panel name="{{ $key }}">
-                        <div class="flex items-center justify-between mb-2">
-                            <span class="font-semibold">{{ $service['label'] }}</span>
-                            <button
+                        <div class="newsletter-embed-{{ $key }}">
+                            <div class="font-medium">{{ $poll->question }}</div>
+                            <ul class="mt-6 text-sm space-y-2 list-disc ml-6">
+                                @foreach ($poll->options as $option)
+                                    <li>
+                                        <a href="{{ route('polls.vote', [
+                                            'poll' => $this->poll,
+                                            'option' => $option->id,
+                                            'contact_email' => $service['merge']
+                                        ]) }}" class="underline">
+                                            {{ $option->label }}
+                                        </a>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <flux:spacer />
+                            <flux:button
                                 type="button"
-                                class="text-xs px-2 py-1 rounded bg-zinc-200 hover:bg-zinc-300"
+                                variant="primary"
                                 onclick="const html = this.closest('.mb-6').querySelector('.newsletter-embed-{{ $key }}').outerHTML;
                                     if (navigator.clipboard && window.ClipboardItem) {
                                         const blob = new Blob([html], { type: 'text/html' });
@@ -149,23 +165,7 @@ new class extends Component {
                                     } else {
                                         navigator.clipboard.writeText(html);
                                     }"
-                            >Copy</button>
-                        </div>
-                        <div class="newsletter-embed-{{ $key }}">
-                            <strong>{{ $poll->question }}</strong>
-                            <ul style="margin-top:8px;">
-                                @foreach ($poll->options as $option)
-                                    <li style="margin-bottom:4px;">
-                                        <a href="{{ route('polls.vote', [
-                                            'poll' => $this->poll,
-                                            'option' => $option->id,
-                                            'contact_email' => $service['merge']
-                                        ]) }}">
-                                            {{ $option->label }}
-                                        </a>
-                                    </li>
-                                @endforeach
-                            </ul>
+                            >Copy</flux:button>
                         </div>
                     </flux:tab.panel>
                 @endforeach

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -17,10 +17,15 @@ new class extends Component {
     {
         $this->options = $this->poll->options()->withCount('responses')->get();
         $this->newsletterServices = [
+            'beehiiv' => ['label' => 'Beehiiv', 'merge' => '{{email}}'],
+            'brevo' => ['label' => 'Brevo', 'merge' => '{{contact.EMAIL}}'],
+            'emailoctopus' => ['label' => 'EmailOctopus', 'merge' => '{{EmailAddress}}'],
+            'ghost' => ['label' => 'Ghost', 'merge' => '{{email}}'],
+            'hubspot' => ['label' => 'HubSpot', 'merge' => '{{personalization_token(\'contact.email\',\'\')}}'],
             'kit' => ['label' => 'Kit', 'merge' => '{{ subscriber.email_address }}'],
-            'beehiiv' => ['label' => 'Beehiiv', 'merge' => '{{ email }}'],
-            'mailerlite' => ['label' => 'MailerLite', 'merge' => '{{ subscriber.email }}'],
-            'custom' => ['label' => 'Custom', 'merge' => 'EMAIL_MERGE_TAG'],
+            'loops' => ['label' => 'Loops', 'merge' => '{email}'],
+            'mailerlite' => ['label' => 'MailerLite', 'merge' => '{$email}'],
+            'sendy' => ['label' => 'Sendy', 'merge' => '[Email]'],
         ];
     }
 
@@ -144,11 +149,13 @@ new class extends Component {
                 <flux:text class="mt-2">Copy and paste this markup into your newsletter platform. The links will prepopulate the contact email field for each subscriber.</flux:text>
             </div>
             <flux:tab.group>
-                <flux:tabs>
-                    @foreach ($this->newsletterServices as $key => $service)
-                        <flux:tab name="{{ $key }}">{{ $service['label'] }}</flux:tab>
-                    @endforeach
-                </flux:tabs>
+                <div class="overflow-x-scroll">
+                    <flux:tabs>
+                        @foreach ($this->newsletterServices as $key => $service)
+                            <flux:tab name="{{ $key }}">{{ $service['label'] }}</flux:tab>
+                        @endforeach
+                    </flux:tabs>
+                </div>
                 @foreach ($this->newsletterServices as $key => $service)
                     <flux:tab.panel name="{{ $key }}">
                         <div x-ref="newsletter{{ ucfirst($key) }}">

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -145,8 +145,8 @@ new class extends Component {
     }">
         <div class="space-y-6">
             <div>
-                <flux:heading size="lg">Embed in Newsletter</flux:heading>
-                <flux:text class="mt-2">Copy and paste this markup into your newsletter platform. The links will prepopulate the contact email field for each subscriber.</flux:text>
+                <flux:heading size="lg">{{ __('Embed in Newsletter') }}</flux:heading>
+                <flux:text class="mt-2">{{ __('Copy and paste this markup into your newsletter platform. The links will prepopulate the contact email field for each subscriber.') }}</flux:text>
             </div>
             <flux:tab.group>
                 <div class="overflow-x-scroll">
@@ -180,8 +180,8 @@ new class extends Component {
                                 type="button"
                                 variant="primary"
                                 @click="copyNewsletter('newsletter{{ ucfirst($key) }}')"
-                                x-text="copied ? 'Copied!' : 'Copy'"
-                            >Copy</flux:button>
+                                x-text="copied ? '{{ __('Copied!') }}' : '{{ __('Copy') }}'"
+                            >{{ __('Copy') }}</flux:button>
                         </div>
                     </flux:tab.panel>
                 @endforeach

--- a/resources/views/livewire/pages/polls/vote.blade.php
+++ b/resources/views/livewire/pages/polls/vote.blade.php
@@ -43,7 +43,7 @@ new #[Layout('components.layouts.guest')] class extends Component {
                 @endforeach
             </flux:radio.group>
 
-            <div x-data>
+            <div>
                 <flux:input
                     type="email"
                     wire:model="contact_email"

--- a/resources/views/livewire/pages/polls/vote.blade.php
+++ b/resources/views/livewire/pages/polls/vote.blade.php
@@ -13,6 +13,7 @@ new #[Layout('components.layouts.guest')] class extends Component {
     #[Validate('required|exists:options,id')]
     public $option = '';
 
+    #[Url]
     #[Validate('nullable|email')]
     public $contact_email = '';
 
@@ -42,12 +43,22 @@ new #[Layout('components.layouts.guest')] class extends Component {
                 @endforeach
             </flux:radio.group>
 
-            <flux:input
-                type="email"
-                wire:model="contact_email"
-                label="{{ __('Your email') }}"
-                badge="{{ __('Optional') }}"
-            />
+            <div x-data>
+                <flux:input
+                    type="email"
+                    wire:model="contact_email"
+                    label="{{ __('Your email') }}"
+                    badge="{{ __('Optional') }}"
+                >
+                    <x-slot name="iconTrailing">
+                        <flux:button
+                            type="button"
+                            @click="$wire.contact_email = ''"
+                            size="sm" variant="subtle" icon="x-mark" class="-mr-1"
+                        />
+                    </x-slot>
+                </flux:input>
+            </div>
 
             <flux:button type="submit" variant="primary">
                 {{ __('Submit') }}


### PR DESCRIPTION
## Summary
- Adds a modal to the poll page for embedding polls in newsletters, supporting major platforms (Beehiiv, Brevo, EmailOctopus, Ghost, HubSpot, Kit, Loops, MailerLite, Sendy)
- Each service uses its own merge tag to prepopulate the contact email field for each subscriber
- Improves UI/UX with Flux tabs, copy-to-clipboard for HTML markup, and i18n for all new strings
- Allows prepopulating and clearing the contact_email field on the vote page via URL and UI

## Test plan
- [ ] Modal appears on poll page with all supported newsletter services
- [ ] Copy button copies correct HTML for each service
- [ ] Links in markup prepopulate contact_email on vote page
- [ ] All new UI is translatable and works in Spanish
- [ ] No regressions in poll voting or embed code

🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>
