### PR TITLE
Polls: open poll button, total/percent responses, dark mode bar

### DIFF
--- a/app/Models/Option.php
+++ b/app/Models/Option.php
@@ -21,4 +21,17 @@ class Option extends Model
     {
         return $this->hasMany(Response::class);
     }
+
+    public function percent(): int
+    {
+        $total = Response::where('poll_id', $this->poll_id)->count();
+
+        if ($total === 0) {
+            return 0;
+        }
+
+        $count = Response::where('option_id', $this->id)->count();
+
+        return round(($count / $total) * 100, 0);
+    }
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -70,6 +70,7 @@
     "Your email": "Tu correo electrónico",
     "Optional": "Opcional",
     "Thank you for voting!": "¡Gracias por votar!",
+    "Total responses": "Total de respuestas",
     "Submit": "Enviar",
     "Responses for": "Respuestas para",
     "Date": "Fecha",

--- a/lang/es.json
+++ b/lang/es.json
@@ -10,7 +10,7 @@
     "Copied!": "¡Copiado!",
     "Copy embed code": "Copiar código de inserción",
     "Copy": "Copiar",
-    "Count": "Cantidad",
+
     "Create a New Poll": "Crear una nueva encuesta",
     "Create account": "Crear cuenta",
     "Create an account": "Crear una cuenta",

--- a/lang/es.json
+++ b/lang/es.json
@@ -39,6 +39,7 @@
     "No options": "Sin opciones",
     "No polls found.": "No se encontraron encuestas.",
     "No responses yet.": "Aún no hay respuestas.",
+    "Open Poll": "Abrir encuesta",
     "Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.": "Una vez que tu cuenta sea eliminada, todos sus recursos y datos serán eliminados permanentemente. Por favor, ingresa tu contraseña para confirmar que deseas eliminar tu cuenta de forma permanente.",
     "Option": "Opción",
     "Options:": "Opciones:",

--- a/lang/es.json
+++ b/lang/es.json
@@ -49,6 +49,8 @@
     "Poll Option 2": "Opción 2",
     "Poll Question": "Pregunta de la encuesta",
     "Polls": "Encuestas",
+    "Percent": "Porcentaje",
+    "Percent": "Porcentaje",
     "Proceed to Checkout": "Proceder al pago",
     "Profile": "Perfil",
     "Remember me": "Recuérdame",

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -93,15 +93,14 @@ new class extends Component {
                         <flux:table.cell>
                             @php
                                 $total = $options->sum('responses_count');
-                                $percent = $total > 0 ? round(($option->responses_count / $total) * 100, 1) : 0;
+                                $percent = $total > 0 ? round(($option->responses_count / $total) * 100, 0) : 0;
                             @endphp
-                            <div class="flex flex-col gap-1">
-                                <span>{{ $percent }}%</span>
-                                <div class="w-full h-2 bg-zinc-200 rounded">
-                                    <div class="h-2 bg-blue-500 rounded" style="width: {{ $percent }}%;"></div>
-                                </div>
-                            </div>
-                        </flux:table.cell>
+<div class="flex items-center gap-1">
+    <div class="flex-1 h-2 bg-zinc-200 rounded">
+        <div class="h-2 bg-blue-500 rounded" style="width: {{ $percent }}%;"></div>
+    </div>
+    <span class="ml-2 w-12 text-right shrink-0 tabular-nums">{{ $percent }}%</span>
+</div>                        </flux:table.cell>
                         <flux:table.cell align="end">
                                 <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom" wire:click="showResponses({{ $option->id }})"></flux:button>
                             </flux:table.cell>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -90,18 +90,19 @@ new class extends Component {
                         <flux:table.row>
                             <flux:table.cell variant="strong">{{ $option->label }}</flux:table.cell>
                             <flux:table.cell>{{ $option->responses_count }}</flux:table.cell>
-<flux:table.cell>
-    @php
-        $total = $options->sum('responses_count');
-        $percent = $total > 0 ? round(($option->responses_count / $total) * 100, 1) : 0;
-    @endphp
-    <div class="flex flex-col gap-1">
-        <span>{{ $percent }}%</span>
-        <div class="w-full h-2 bg-gray-200 rounded">
-            <div class="h-2 bg-blue-500 rounded" style="width: {{ $percent }}%;" role="progressbar" aria-valuenow="{{ $percent }}" aria-valuemin="0" aria-valuemax="100"></div>
-        </div>
-    </div>
-</flux:table.cell>                            <flux:table.cell align="end">
+                        <flux:table.cell>
+                            @php
+                                $total = $options->sum('responses_count');
+                                $percent = $total > 0 ? round(($option->responses_count / $total) * 100, 1) : 0;
+                            @endphp
+                            <div class="flex flex-col gap-1">
+                                <span>{{ $percent }}%</span>
+                                <div class="w-full h-2 bg-zinc-200 rounded">
+                                    <div class="h-2 bg-blue-500 rounded" style="width: {{ $percent }}%;"></div>
+                                </div>
+                            </div>
+                        </flux:table.cell>
+                        <flux:table.cell align="end">
                                 <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom" wire:click="showResponses({{ $option->id }})"></flux:button>
                             </flux:table.cell>
                         </flux:table.row>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -90,14 +90,18 @@ new class extends Component {
                         <flux:table.row>
                             <flux:table.cell variant="strong">{{ $option->label }}</flux:table.cell>
                             <flux:table.cell>{{ $option->responses_count }}</flux:table.cell>
-                            <flux:table.cell>
-                                @if($options->sum('responses_count') > 0)
-                                    {{ number_format(($option->responses_count / $options->sum('responses_count')) * 100, 2) }}%
-                                @else
-                                    0%
-                                @endif
-                            </flux:table.cell>
-                            <flux:table.cell align="end">
+<flux:table.cell>
+    @php
+        $total = $options->sum('responses_count');
+        $percent = $total > 0 ? round(($option->responses_count / $total) * 100, 1) : 0;
+    @endphp
+    <div class="flex flex-col gap-1">
+        <span>{{ $percent }}%</span>
+        <div class="w-full h-2 bg-gray-200 rounded">
+            <div class="h-2 bg-blue-500 rounded" style="width: {{ $percent }}%;" role="progressbar" aria-valuenow="{{ $percent }}" aria-valuemin="0" aria-valuemax="100"></div>
+        </div>
+    </div>
+</flux:table.cell>                            <flux:table.cell align="end">
                                 <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom" wire:click="showResponses({{ $option->id }})"></flux:button>
                             </flux:table.cell>
                         </flux:table.row>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -59,6 +59,7 @@ new class extends Component {
             <flux:modal.trigger name="embed-newsletter">
                 <flux:button>{{ __('Embed in Newsletter') }}</flux:button>
             </flux:modal.trigger>
+            <flux:button :href="route('polls.vote', ['poll' => $poll])" target="_blank">{{ __('Open Poll') }}</flux:button>
             <flux:button variant="primary" @click="copyHtml('embed')" x-text="copied ? '{{ __('Copied!') }}' : '{{ __('Copy embed code') }}'">{{ __('Copy embed code') }}</flux:button>
         </div>
     </div>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -75,6 +75,7 @@ new class extends Component {
 
     <div class="mt-10">
         <flux:heading size="lg">{{ $poll->question }}</flux:heading>
+        <flux:text class="mt-1">{{ __('Total responses') }}: {{ $options->sum('responses_count') }}</flux:text>
 
         @if($options->count())
             <flux:table class="mt-2">

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -82,6 +82,7 @@ new class extends Component {
                 <flux:table.columns>
                     <flux:table.column>{{ __('Option') }}</flux:table.column>
                     <flux:table.column>{{ __('Count') }}</flux:table.column>
+<flux:table.column>{{ __('Percent') }}</flux:table.column>
                 </flux:table.columns>
 
                 <flux:table.rows>
@@ -89,6 +90,13 @@ new class extends Component {
                         <flux:table.row>
                             <flux:table.cell variant="strong">{{ $option->label }}</flux:table.cell>
                             <flux:table.cell>{{ $option->responses_count }}</flux:table.cell>
+                            <flux:table.cell>
+                                @if($options->sum('responses_count') > 0)
+                                    {{ number_format(($option->responses_count / $options->sum('responses_count')) * 100, 2) }}%
+                                @else
+                                    0%
+                                @endif
+                            </flux:table.cell>
                             <flux:table.cell align="end">
                                 <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom" wire:click="showResponses({{ $option->id }})"></flux:button>
                             </flux:table.cell>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -95,11 +95,11 @@ new class extends Component {
                                 $total = $options->sum('responses_count');
                                 $percent = $total > 0 ? round(($option->responses_count / $total) * 100, 0) : 0;
                             @endphp
-<div class="flex items-center gap-1">
+<div class="flex items-center gap-2">
     <div class="flex-1 h-2 bg-zinc-200 rounded">
         <div class="h-2 bg-blue-500 rounded" style="width: {{ $percent }}%;"></div>
     </div>
-    <span class="ml-2 w-12 text-right shrink-0 tabular-nums">{{ $percent }}%</span>
+    <span class="w-8 text-right shrink-0 tabular-nums">{{ $percent }}%</span>
 </div>                        </flux:table.cell>
                         <flux:table.cell align="end">
                                 <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom" wire:click="showResponses({{ $option->id }})"></flux:button>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -91,15 +91,11 @@ new class extends Component {
                             <flux:table.cell variant="strong">{{ $option->label }}</flux:table.cell>
                             <flux:table.cell>{{ $option->responses_count }}</flux:table.cell>
                         <flux:table.cell>
-                            @php
-                                $total = $options->sum('responses_count');
-                                $percent = $total > 0 ? round(($option->responses_count / $total) * 100, 0) : 0;
-                            @endphp
-<div class="flex items-center gap-2">
+                            <div class="flex items-center gap-2">
     <div class="flex-1 h-2 bg-zinc-200 rounded">
-        <div class="h-2 bg-blue-500 rounded" style="width: {{ $percent }}%;"></div>
+        <div class="h-2 bg-blue-500 rounded" style="width: {{ $option->percent() }}%;"></div>
     </div>
-    <span class="w-8 text-right shrink-0 tabular-nums">{{ $percent }}%</span>
+    <span class="w-8 text-right shrink-0 tabular-nums">{{ $option->percent() }}%</span>
 </div>                        </flux:table.cell>
                         <flux:table.cell align="end">
                                 <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom" wire:click="showResponses({{ $option->id }})"></flux:button>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -92,11 +92,12 @@ new class extends Component {
                             <flux:table.cell>{{ $option->responses_count }}</flux:table.cell>
                         <flux:table.cell>
                             <div class="flex items-center gap-2">
-    <div class="flex-1 h-2 bg-zinc-200 rounded">
-        <div class="h-2 bg-blue-500 rounded" style="width: {{ $option->percent() }}%;"></div>
-    </div>
-    <span class="w-8 text-right shrink-0 tabular-nums">{{ $option->percent() }}%</span>
-</div>                        </flux:table.cell>
+                                <div class="flex-1 h-2 bg-zinc-200 dark:bg-zinc-700 rounded">
+                                    <div class="h-2 bg-blue-500 dark:bg-blue-400 rounded" style="width: {{ $option->percent() }}%;"></div>
+                                </div>
+                                <span class="w-8 text-right shrink-0 tabular-nums">{{ $option->percent() }}%</span>
+                            </div>
+                        </flux:table.cell>
                         <flux:table.cell align="end">
                                 <flux:button variant="ghost" size="sm" icon="ellipsis-horizontal" inset="top bottom" wire:click="showResponses({{ $option->id }})"></flux:button>
                             </flux:table.cell>

--- a/resources/views/livewire/pages/polls/show.blade.php
+++ b/resources/views/livewire/pages/polls/show.blade.php
@@ -81,7 +81,7 @@ new class extends Component {
             <flux:table class="mt-2">
                 <flux:table.columns>
                     <flux:table.column>{{ __('Option') }}</flux:table.column>
-                    <flux:table.column>{{ __('Count') }}</flux:table.column>
+                    <flux:table.column>{{ __('Responses') }}</flux:table.column>
 <flux:table.column>{{ __('Percent') }}</flux:table.column>
                 </flux:table.columns>
 


### PR DESCRIPTION
## Summary
- Adds an 'Open Poll' button to the poll show page
- Shows total responses and percent for each option
- Adds a dark mode friendly percentage indicator bar
- Refactors percentage logic to Option model
- Updates translations and applies PHP linting

🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>
